### PR TITLE
cpn syslog error

### DIFF
--- a/opennms/src/main/java/org/opennms/oce/tools/NodeAndFactsGenerator.java
+++ b/opennms/src/main/java/org/opennms/oce/tools/NodeAndFactsGenerator.java
@@ -254,9 +254,13 @@ public class NodeAndFactsGenerator {
                 Date messageTime;
 
                 // Parse the syslog record and extract the date from the message
-                GenericSyslogMessage parsedSyslogMessage = GenericSyslogMessage.fromCpn(syslog.getEventId(),
-                        nodeAndFacts.getCpnHostname(), syslog.getDetailedDescription());
-                messageTime = parsedSyslogMessage.getDate();
+                try {
+                    GenericSyslogMessage parsedSyslogMessage = GenericSyslogMessage.fromCpn(syslog.getEventId(), nodeAndFacts.getCpnHostname(), syslog.getDetailedDescription());
+                    messageTime = parsedSyslogMessage.getDate();
+                } catch (NullPointerException npe) {
+                    // skip
+                    continue;
+                }
 
                 // Compute the delta between the message date, and the time at which the event was processed
                 deltas.add(Math.abs(processedTime.getTime() - messageTime.getTime()));


### PR DESCRIPTION
I think it's better to skip but wanted to run it by both of you....

The offending syslog was:

11:27:58.242 [main] ERROR org.opennms.oce.tools.tsaudit.SyslogParser - Failed to parse date for [%BGP-3-NOTIFICATION: sent to neighbor 39.243.10.153 4/0 (hold time expired) 0 bytes] : Insufficient fields to produce a ZonedDateTime: month and dayOfMonth are required
